### PR TITLE
Stop parallel scans slamming resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Forker from old repo [vscode-extension-auto-import](https://github.com/martinopp
 * [zhaoshengjun](https://github.com/zhaoshengjun)
 * [soates](https://github.com/soates)
 * [third774](https://github.com/third774)
+* [benkaiser](https://github.com/benkaiser)
 
 ----
 
@@ -34,6 +35,11 @@ Forker from old repo [vscode-extension-auto-import](https://github.com/martinopp
 ----
 
 ## Changelog
+
+### 1.4.4
+
+- Make file reading files synchonous to avoid hammering the filesystem.
+- Ensure only one scan process is operating at a time.
 
 ### 1.4.2
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-extension-auto-import",
   "displayName": "Auto Import - ES6, TS, JSX, TSX",
   "description": "Automatically finds, parses and provides code actions and code completion for all available imports. Works with JavaScript and TypeScript. [Forked]",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "contributors": [
     {
       "name": "soates",
@@ -23,6 +23,10 @@
     {
       "name": "martinoppitz",
       "url": "https://github.com/martinoppitz"
+    },
+    {
+      "name": "benkaiser",
+      "url": "https://github.com/benkaiser"
     }
   ],
   "publisher": "NuclleaR",

--- a/src/import-fixer.ts
+++ b/src/import-fixer.ts
@@ -18,11 +18,11 @@ export class ImportFixer {
     }
 
     public fix(document: vscode.TextDocument, range: vscode.Range,
-        context: vscode.CodeActionContext, token: vscode.CancellationToken, imports: Array<ImportObject>): void {
+        context: vscode.CodeActionContext, token: vscode.CancellationToken, imports: Array<ImportObject>): Thenable<boolean> {
 
         let edit = this.getTextEdit(document, imports);
 
-        vscode.workspace.applyEdit(edit);
+        return vscode.workspace.applyEdit(edit);
     }
 
     public getTextEdit(document: vscode.TextDocument, imports: Array<ImportObject>) {


### PR DESCRIPTION
Currently when file change notifications are emitted a scan is performed
per every change. This can be troublesome especially during build processes
where potentially hundreds of files may change. The fix here is to ensure only
one scan is operating at a time.

We also are opening potentially thousands of files in parallel when running scans.
Instead we want to open them synchonously ensuring that they are closed and we don't
hog system resources for file opens. This could be optimized in the future to open a
small number in parallel (say 10) if the performance is needed here.