### PR TITLE
fix weird falsy `mArr`

### DIFF
--- a/src/import-scanner.ts
+++ b/src/import-scanner.ts
@@ -103,11 +103,8 @@ export class ImportScanner {
         if (matches != null) {
             matches.forEach(m => {
                 //this allows us to reliably gets the last string (not splitting on spaces)
+                regExp.lastIndex = 0;
                 const mArr = regExp.exec(m);
-                if(mArr === null){
-                    //this is a weird situation that shouldn't ever happen. but does?
-                    return;
-                }
                 const workingFile: string = mArr[mArr.length - 1];
                 const isDefault = m.indexOf('default') !== -1;
                 ImportDb.saveImport(workingFile, data, file, isDefault, null);


### PR DESCRIPTION
This fixes the `"weird situation that shouldn't ever happen"`, the cause is that RegExp is actually not stateless. It has a "cursor" so if you run `exec` multiple times, it will only search **after** the last match.

This was causing some of my own exports to not be registered so I went in to find the problem.

Simple solution really but definitely weird!

[More info on the cause of this issue.](https://stackoverflow.com/questions/11477415/why-does-javascripts-regex-exec-not-always-return-the-same-value)