### PR TITLE
[Fix] Remove duplication with auto completions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-extension-auto-import",
   "displayName": "Auto Import - ES6, TS, JSX, TSX",
   "description": "Automatically finds, parses and provides code actions and code completion for all available imports. Works with JavaScript and TypeScript. [Forked]",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "contributors": [
     {
       "name": "soates",

--- a/src/helpers/package-name-helper.ts
+++ b/src/helpers/package-name-helper.ts
@@ -1,5 +1,10 @@
+const isQuote = char => char === `"` || char === `'`;
+
 export class PackageNameHelper {
     static isPackageNameQuoted(packageName: string): boolean {
-        return !!packageName.match(/['"].*['"]/g);
+        const first = packageName[0];
+        const last = packageName[packageName.length - 1];
+
+        return isQuote(first) && isQuote(last);
     }
 }

--- a/src/helpers/package-name-helper.ts
+++ b/src/helpers/package-name-helper.ts
@@ -1,4 +1,4 @@
-const isQuote = char => char === `"` || char === `'`;
+const isQuote = (char: string) => char === `"` || char === `'`;
 
 export class PackageNameHelper {
     static isPackageNameQuoted(packageName: string): boolean {

--- a/src/helpers/package-name-helper.ts
+++ b/src/helpers/package-name-helper.ts
@@ -1,0 +1,5 @@
+export class PackageNameHelper {
+    static isPackageNameQuoted(packageName: string): boolean {
+        return !!packageName.match(/['"].*['"]/g);
+    }
+}

--- a/src/import-completion.ts
+++ b/src/import-completion.ts
@@ -1,6 +1,7 @@
 import { PathHelper } from './helpers/path-helper';
 import { ImportDb, ImportObject } from './import-db';
 import { ImportFixer } from './import-fixer';
+import { PackageNameHelper } from './helpers/package-name-helper';
 
 import * as vscode from 'vscode';
 
@@ -36,6 +37,7 @@ export class ImportCompletion implements vscode.CompletionItemProvider {
                 .filter(f => {
                     return f.name.toLowerCase().indexOf(wordToComplete) > -1
                 })
+                .filter(imp => PackageNameHelper.isPackageNameQuoted(imp.getPath(document)))
                 .map(i => this.buildCompletionItem(i, document))
             );
         })


### PR DESCRIPTION
Hello everybody,

I've found that this extension shows duplicates one with quotations and another without for example:

`import Text from "react-native"`
and
`import Text from react-native`

And choosing the last option doesn't import the dependency, while you get a wrong feedback like it's been imported.

So, I've modified the package to fix this issue.
- I've added a helper for package name with one static method `isPackageNameQuoted()` to test against the package name.
- Used that predicate for filtering from `importsDb`

😺 