### PR TITLE
Fix null mArr and default exports

### DIFF
--- a/src/import-db.ts
+++ b/src/import-db.ts
@@ -80,8 +80,10 @@ export class ImportDb {
 
         let exists = ImportDb.imports.findIndex(m => m.name === obj.name && m.file.fsPath === file.fsPath);
 
-        if (exists === -1) {
+        if (exists === -1 || ImportDb.imports[exists].isDefault) {
             ImportDb.imports.push(obj);
+        } else {
+            ImportDb.imports.splice(exists, 0, obj);
         }
 
     }

--- a/src/import-scanner.ts
+++ b/src/import-scanner.ts
@@ -103,6 +103,7 @@ export class ImportScanner {
         if (matches != null) {
             matches.forEach(m => {
                 //this allows us to reliably gets the last string (not splitting on spaces)
+                regExp.lastIndex = 0 // reset regExp state (this is what causes the below "weird situation" making every other exec fail because it uses the last match index)
                 const mArr = regExp.exec(m);
                 if(mArr === null){
                     //this is a weird situation that shouldn't ever happen. but does?


### PR DESCRIPTION
This is a fix for both the null mArr but also a fix for the case where you default export a variable that is a named export. See below

```js
import React from 'react';
import { connect } from 'react-redux';

export const TestComponent = props => {
  return <div>TestComponent</div>;
};

const mapStateToProps = state => ({});

const mapDispatchToProps = {};

export default connect(mapStateToProps, mapDispatchToProps)(TestComponent);
``` 

auto importing this would import 
```js
import { TestComponent } from './path/TestComponent';
```
instead of the "correct" 
```js
import TestComponent from './path/TestComponent';
``` 